### PR TITLE
Fix for "TypeError: get() takes exactly 1 argument (2 given)".

### DIFF
--- a/wifilocate.py
+++ b/wifilocate.py
@@ -56,7 +56,7 @@ def locate(scan_result):
     qs = [('browser', 'firefox'), ('sensor', 'true')]
     qs.extend(('wifi', 'mac:{0}|ssid:{1}|ss:{2}'.format(*tup))
               for tup in scan_result)
-    response = requests.get(url, qs)
+    response = requests.get(url, params=qs)
     res = response.json()
 
     return res['accuracy'], \


### PR DESCRIPTION
Hi

I got this when trying to use your code:

> Traceback (most recent call last):
>   File "locate.py", line 4, in <module>
>     accuracy, latlng = locate(linux_scan(device="wlan0"))
>   File "/usr/local/lib/python2.7/dist-packages/wifilocate.py", line 59, in locate
>     response = requests.get(url, qs)
> TypeError: get() takes exactly 1 argument (2 given)

Here's a fix for it.